### PR TITLE
Upgrade to aioredis v2.0

### DIFF
--- a/aadiscordbot/bot.py
+++ b/aadiscordbot/bot.py
@@ -34,6 +34,9 @@ from aadiscordbot.cogs.utils.exceptions import NotAuthenticated
 from . import bot_tasks
 from .cogs.utils import context
 
+
+BROKER_URL = getattr(settings, "BROKER_URL", "redis://localhost:6379/0")
+
 description = """
 AuthBot is watching...
 """
@@ -149,9 +152,9 @@ class AuthBot(commands.Bot):
         print(f"Authbot Started with command prefix {DISCORD_BOT_PREFIX}")
 
         self.redis = None
-        self.redis = self.loop.run_until_complete(aioredis.create_pool(getattr(
-            settings, "BROKER_URL", "redis://localhost:6379/0"), minsize=5, maxsize=10))
-        print('redis pool started', self.redis)
+
+        self.redis = self.loop.run_until_complete(
+                aioredis.from_url(BROKER_URL, encoding="utf-8", decode_responses=True))
         self.client_id = client_id
         self.session = aiohttp.ClientSession(loop=self.loop)
 
@@ -160,9 +163,7 @@ class AuthBot(commands.Bot):
         self.rate_limits = RateLimiter()
         self.statistics = Statistics()
 
-        self.message_connection = Connection(
-            getattr(settings, "BROKER_URL", 'redis://localhost:6379/0'))
-
+        self.message_connection = Connection(BROKER_URL)
         queues = []
         for que in queue_keys:
             queues.append(Queue(que))

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
         "allianceauth>=2.9.0,<4.0.0",
         "py-cord>2.0.0,<3.0.0",
         "pendulum>=2.1.2,<3.0.0",
-        "aioredis==2.0.0"
+        "aioredis>=2.0.0, <3.0.0"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
         "allianceauth>=2.9.0,<4.0.0",
         "py-cord>2.0.0,<3.0.0",
         "pendulum>=2.1.2,<3.0.0",
-        "aioredis<2.0.0"
+        "aioredis==2.0.0"
     ],
 )


### PR DESCRIPTION
Reworked deprecated connection functions.

Tested bot commands and messages locally. Bot seems to communicate with a ACL secured Redis 6.0 without issue.

Tested bot with Redis 5.0.8, standard default setup with a docker container.

connection string for BROKER_URL can remain the same if using either 5.0.8 or 6.0 Redis locally. If acl's are to be used the connection string needs to specify the additional information such as a username and password as described in the [celery-redis documentation](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html). see attached images.

![image](https://user-images.githubusercontent.com/5779741/230277081-891e951a-6a9e-423f-9a50-7b738a0a5c4d.png)

Migration documentation:
https://aioredis.readthedocs.io/en/v2.0.1/migration/