### PR TITLE
[FIX] Auth Link

### DIFF
--- a/aadiscordbot/cogs/about.py
+++ b/aadiscordbot/cogs/about.py
@@ -50,7 +50,7 @@ class About(commands.Cog):
         embed.add_field(name="Unwilling Monitorees:",
                         value=members, inline=True)
         embed.add_field(
-            name="Auth Link", value=f"[{get_site_url()}]({get_site_url()})", inline=False
+            name="Auth Link", value=get_site_url(), inline=False
         )
         embed.add_field(
             name="Version", value=f"{__version__}@{__branch__}", inline=False
@@ -90,7 +90,7 @@ class About(commands.Cog):
                         value=roles, inline=True)
 
         embed.add_field(
-            name="Auth Link", value=f"[{get_site_url()}]({get_site_url()})", inline=False
+            name="Auth Link", value=get_site_url(), inline=False
         )
 
         return await ctx.respond(embed=embed)

--- a/aadiscordbot/cogs/auth.py
+++ b/aadiscordbot/cogs/auth.py
@@ -43,7 +43,7 @@ class Auth(commands.Cog):
         url = get_site_url()
 
         embed.add_field(
-            name="Auth Link", value=f"[{url}]({url})", inline=False
+            name="Auth Link", value=url, inline=False
         )
 
         return await ctx.send(embed=embed)
@@ -65,7 +65,7 @@ class Auth(commands.Cog):
         url = get_site_url()
 
         embed.add_field(
-            name="Auth Link", value=f"[{url}]({url})", inline=False
+            name="Auth Link", value=url, inline=False
         )
         """
         embed.add_field(


### PR DESCRIPTION
Discord fucked up their MD parsing and MD is not needed here …

![](https://cdn.discordapp.com/attachments/1065784868849598564/1123274199641899028/image.png)
